### PR TITLE
Support bigquery tag

### DIFF
--- a/infer.go
+++ b/infer.go
@@ -38,7 +38,18 @@ func inferObject(data reflect.Value) (bigquery.Schema, error) {
 				continue
 			}
 
-			fieldSchema, err := inferField(data.Type().Field(i).Name, field)
+			var name string
+			tag := fieldInfo.Tag.Get("bigquery")
+			switch tag {
+			case "":
+				name = fieldInfo.Name
+			case "-":
+				continue
+			default:
+				name = tag
+			}
+
+			fieldSchema, err := inferField(name, field)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Supporting `bigquery` tag like following

```go
type Sample struct {
  Str      string `bigquery:"str"`
  NotInfer int    `bigquery:"-"`
}
```

- If the field has `bigquery:"hoge"` tag, field name will be "hoge"
- If the field has `bigquery:"-"` tag, the field will be skipped