### PR TITLE
Support JSON tag as secondary name hint

### DIFF
--- a/infer.go
+++ b/infer.go
@@ -38,15 +38,21 @@ func inferObject(data reflect.Value) (bigquery.Schema, error) {
 				continue
 			}
 
+			jsonTag := fieldInfo.Tag.Get("json")
+			bqTag := fieldInfo.Tag.Get("bigquery")
+
 			var name string
-			tag := fieldInfo.Tag.Get("bigquery")
-			switch tag {
-			case "":
-				name = fieldInfo.Name
-			case "-":
+			switch {
+			case bqTag == "-":
 				continue
+			case bqTag != "":
+				name = bqTag
+			case jsonTag == "-":
+				continue
+			case jsonTag != "":
+				name = jsonTag
 			default:
-				name = tag
+				name = fieldInfo.Name
 			}
 
 			fieldSchema, err := inferField(name, field)

--- a/infer_test.go
+++ b/infer_test.go
@@ -578,6 +578,53 @@ func TestTag(t *testing.T) {
 				},
 			},
 		},
+		"prioritize bigquery tag than json": {
+			input: struct {
+				Str string `bigquery:"blue" json:"red"`
+			}{
+				Str: "a",
+			},
+			expect: bigquery.Schema{
+				{
+					Name: "blue",
+					Type: bigquery.StringFieldType,
+				},
+			},
+		},
+		"use json tag if bigquery tag is not defined": {
+			input: struct {
+				Str string `json:"red"`
+			}{
+				Str: "a",
+			},
+			expect: bigquery.Schema{
+				{
+					Name: "red",
+					Type: bigquery.StringFieldType,
+				},
+			},
+		},
+		"skip if bigquery has '-' tag even if having json tag": {
+			input: struct {
+				Str string `bigquery:"-" json:"red"`
+			}{
+				Str: "a",
+			},
+			expect: nil,
+		},
+		"do not skip even if having '-' tag in json": {
+			input: struct {
+				Str string `bigquery:"red" json:"-"`
+			}{
+				Str: "a",
+			},
+			expect: bigquery.Schema{
+				{
+					Name: "red",
+					Type: bigquery.StringFieldType,
+				},
+			},
+		},
 	}
 
 	for name, tc := range testCases {


### PR DESCRIPTION
- bqs now check `json` tag in struct also
- If `bigquery` tag exists, it will be prioritized even if `json` tag exists
